### PR TITLE
saveDefaultConfig doesn't overwrite!

### DIFF
--- a/src/main/kotlin/dev/cube1/minecord/Minecord.kt
+++ b/src/main/kotlin/dev/cube1/minecord/Minecord.kt
@@ -61,10 +61,7 @@ class Minecord : JavaPlugin() {
 
     override fun onEnable() {
         instance = this
-        if (!dataFolder.exists()) {
-            this.saveDefaultConfig()
-            logger.info("MineCord - Initialized configuration!")
-        }
+        this.saveDefaultConfig()
 
         loadJDAModule()
         loadEventListener()


### PR DESCRIPTION
saveDefaultConfig 메소드는 기존 콘피그를 덮어씌우지 않습니다. 이로, 만약 Minecord 폴더가 존재한다면 기본 config.yml이 생성되지 않을 수 있습니다.